### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -7,6 +7,9 @@
 
 name: Publish Release to Maven Central
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]   # 手动发布


### PR DESCRIPTION
Potential fix for [https://github.com/sjf4j-projects/sjf4j/security/code-scanning/1](https://github.com/sjf4j-projects/sjf4j/security/code-scanning/1)

To fix the problem, we need to add a `permissions` key to limit the workflow's use of the `GITHUB_TOKEN` to the least privileges required. Since the workflow does not interact with the repository contents in a way that requires write access and appears to use secrets for publishing instead of the `GITHUB_TOKEN`, we can safely limit the permissions to `contents: read`.

The best practice is to place `permissions` at the top level of the workflow so it applies to all jobs, unless a job has its own override (which isn't the case here). Place `permissions: contents: read` just below the `name:` or after the `on:`, before `jobs:`.

No import or other method is needed; only a YAML structural edit is required in `.github/workflows/gradle-publish.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
